### PR TITLE
patch for uconsole future lcd screen , CM4 only

### DIFF
--- a/drivers/gpu/drm/panel/panel-cwu50-cm4.c
+++ b/drivers/gpu/drm/panel/panel-cwu50-cm4.c
@@ -14,7 +14,7 @@ struct cwu50 {
 	struct device *dev;
 	struct drm_panel panel;
 	struct regulator *supply;
-	struct gpio_desc *reset_gpio;
+	struct gpio_desc *id_gpio;
 	struct backlight_device *backlight;
 	bool prepared;
 	bool enabled;
@@ -265,6 +265,273 @@ static void cwu50_init_sequence(struct cwu50 *ctx)
 	msleep (20);
 	dcs_write_seq(0x35,0x00);
 }
+static int cwu50_init_sequence2(struct cwu50 *ctx)
+{
+	struct mipi_dsi_device *dsi = to_mipi_dsi_device(ctx->dev);
+	int err;
+	dcs_write_seq(0xE0,0x00);
+
+	//--- PASSWORD	----//
+	dcs_write_seq(0xE1,0x93);
+	dcs_write_seq(0xE2,0x65);
+	dcs_write_seq(0xE3,0xF8);
+	dcs_write_seq(0x80,0x03);//03:4lane 02:3lane 01:2lane
+
+
+	//--- Page1  ----//
+	dcs_write_seq(0xE0,0x01);
+
+	//Set VCOM
+	dcs_write_seq(0x00,0x00);
+	dcs_write_seq(0x01,0x62);
+	dcs_write_seq(0x03,0x10);
+	dcs_write_seq(0x04,0x6A);
+
+	//Set Gamma Power, VGMP,VGMN,VGSP,VGSN
+	dcs_write_seq(0x17,0x00);
+	dcs_write_seq(0x18,0xDF); // VGMP=4.9V
+	dcs_write_seq(0x19,0x01); // VGSP=0.3V
+	dcs_write_seq(0x1A,0x00);
+	dcs_write_seq(0x1B,0xDF); // VGMN=-4.9V
+	dcs_write_seq(0x1C,0x01); // VGSN=0.3V
+
+	//VCL
+	dcs_write_seq(0x24,0xFE);
+
+	//Set Panel
+	dcs_write_seq(0x37,0x09);	//SS=1,BGR=1
+
+	//SET RGBCYC
+	dcs_write_seq(0x38,0x04);	//JDT=100 column inversion
+	dcs_write_seq(0x39,0x08);	//RGB_N_EQ1
+	dcs_write_seq(0x3A,0x12);	//RGB_N_EQ2
+	dcs_write_seq(0x3C,0x78);	//SET EQ3 for TE_H
+	dcs_write_seq(0x3D,0xFF);
+	dcs_write_seq(0x3E,0xFF);
+	dcs_write_seq(0x3F,0xFF);
+
+	//Set TCON
+	dcs_write_seq(0x40,0x04);	//RSO 04h=720, 05h=768, 06h=800
+	dcs_write_seq(0x41,0xA0);	//LN=640->1280 line
+	dcs_write_seq(0x42,0x7F);  //SLT=12.7us
+	dcs_write_seq(0x43,0x10);  //VFP
+	dcs_write_seq(0x44,0x17);  //VBP =24
+	dcs_write_seq(0x45,0x40);
+
+	//dcs_write_seq(0x4A,0x35);//BIST MODE 35:AUTO
+
+	//--- power voltage  ----//
+	dcs_write_seq(0x55,0x02);	//DCDCM=0011, JD5001
+	//dcs_write_seq(0x56,0x01);
+	dcs_write_seq(0x57,0x69);
+	//dcs_write_seq(0x58,0x0A);
+	dcs_write_seq(0x59,0x2A);	//VCL = -2.7V, AVEE=-5.5V
+	dcs_write_seq(0x5A,0x1A);	//VGH = +12.2V
+	dcs_write_seq(0x5B,0x1A);	//VGL = -12.2V
+
+	//--- Gamma2.2	----//	//G2.2	  //G2.5
+	dcs_write_seq(0x5D,0x7F);  //0x7F	//0x7F
+	dcs_write_seq(0x5E,0x67);  //0x67	//0x65
+	dcs_write_seq(0x5F,0x58);  //0x58	//0x55
+	dcs_write_seq(0x60,0x4B);  //0x4B	//0x47
+	dcs_write_seq(0x61,0x47);  //0x47	//0x42
+	dcs_write_seq(0x62,0x39);  //0x39	//0x32
+	dcs_write_seq(0x63,0x3D);  //0x3D	//0x36
+	dcs_write_seq(0x64,0x25);  //0x25	//0x1D
+	dcs_write_seq(0x65,0x3D);  //0x3D	//0x36
+	dcs_write_seq(0x66,0x3C);  //0x3C	//0x34
+	dcs_write_seq(0x67,0x3C);  //0x3C	//0x35
+	dcs_write_seq(0x68,0x5B);  //0x5B	//0x51
+	dcs_write_seq(0x69,0x4A);  //0x4A	//0x3D
+	dcs_write_seq(0x6A,0x50);  //0x50	//0x40
+	dcs_write_seq(0x6B,0x42);  //0x42	//0x31
+	dcs_write_seq(0x6C,0x3B);  //0x3B	//0x2C
+	dcs_write_seq(0x6D,0x2D);  //0x2D	//0x1F
+	dcs_write_seq(0x6E,0x19);  //0x19	//0x0E
+	dcs_write_seq(0x6F,0x00);  //0x00	//0x00
+	dcs_write_seq(0x70,0x7F);  //0x7F	//0x7F
+	dcs_write_seq(0x71,0x67);  //0x67	//0x65
+	dcs_write_seq(0x72,0x58);  //0x58	//0x55
+	dcs_write_seq(0x73,0x4B);  //0x4B	//0x47
+	dcs_write_seq(0x74,0x47);  //0x47	//0x42
+	dcs_write_seq(0x75,0x39);  //0x39	//0x32
+	dcs_write_seq(0x76,0x3D);  //0x3D	//0x36
+	dcs_write_seq(0x77,0x25);  //0x25	//0x1D
+	dcs_write_seq(0x78,0x3D);  //0x3D	//0x36
+	dcs_write_seq(0x79,0x3C);  //0x3C	//0x34
+	dcs_write_seq(0x7A,0x3C);  //0x3C	//0x35
+	dcs_write_seq(0x7B,0x5B);  //0x5B	//0x51
+	dcs_write_seq(0x7C,0x4A);  //0x4A	//0x3D
+	dcs_write_seq(0x7D,0x50);  //0x50	//0x40
+	dcs_write_seq(0x7E,0x42);  //0x42	//0x31
+	dcs_write_seq(0x7F,0x3B);  //0x3B	//0x2C
+	dcs_write_seq(0x80,0x2D);  //0x2D	//0x1F
+	dcs_write_seq(0x81,0x19);  //0x19	//0x0E
+	dcs_write_seq(0x82,0x00);  //0x00	//0x00
+
+
+	//Page2, for GIP
+	dcs_write_seq(0xE0,0x02);
+
+	//GIP_L Pin mapping
+	dcs_write_seq(0x00,0x5F);	//GCL
+	dcs_write_seq(0x01,0x5F);	//VSS->VGL
+	dcs_write_seq(0x02,0x44);	//CLK1->CKV0
+	dcs_write_seq(0x03,0x46);	//CKK3->CKV2
+	dcs_write_seq(0x04,0x48);	//CLK5->CKV4
+	dcs_write_seq(0x05,0x4A);	//CLK7->CKV6
+	dcs_write_seq(0x06,0x5F);	//VGL
+	dcs_write_seq(0x07,0x5F);	//VGL
+	dcs_write_seq(0x08,0x5F);	//VGL
+	dcs_write_seq(0x09,0x5F);	//NC
+	dcs_write_seq(0x0A,0x5F);	//NC
+	dcs_write_seq(0x0B,0x5F);	//NC //
+	dcs_write_seq(0x0C,0x5F);	//NC
+	dcs_write_seq(0x0D,0x5F);	//NC
+	dcs_write_seq(0x0E,0x5F);	//NC //
+	dcs_write_seq(0x0F,0x5F);	//NC
+	dcs_write_seq(0x10,0x5F);	//NC
+	dcs_write_seq(0x11,0x5F);	//NC //
+	dcs_write_seq(0x12,0x5E);	//GCH
+	dcs_write_seq(0x13,0x5E);	//VDD->VGH
+	dcs_write_seq(0x14,0x40);	//STV1
+	dcs_write_seq(0x15,0x42);	//STV3
+
+	//GIP_R Pin mapping
+	dcs_write_seq(0x16,0x5F);	//GCL
+	dcs_write_seq(0x17,0x5F);	//VSS->VGL
+	dcs_write_seq(0x18,0x45);	//CLK2->CKV1
+	dcs_write_seq(0x19,0x47);	//CKK4->CKV3
+	dcs_write_seq(0x1A,0x49);	//CLK6->CKV5
+	dcs_write_seq(0x1B,0x4B);	//CLK8->CKV7
+	dcs_write_seq(0x1C,0x5F);	//VGL
+	dcs_write_seq(0x1D,0x5F);	//VGL
+	dcs_write_seq(0x1E,0x5F);	//VGL
+	dcs_write_seq(0x1F,0x5F);	//NC
+	dcs_write_seq(0x20,0x5F);	//NC
+	dcs_write_seq(0x21,0x5F);	//NC //
+	dcs_write_seq(0x22,0x5F);	//NC
+	dcs_write_seq(0x23,0x5F);	//NC
+	dcs_write_seq(0x24,0x5F);	//NC //
+	dcs_write_seq(0x25,0x5F);	//NC
+	dcs_write_seq(0x26,0x5F);	//NC
+	dcs_write_seq(0x27,0x5F);	//NC //
+	dcs_write_seq(0x28,0x5E);	//GCH
+	dcs_write_seq(0x29,0x5E);	//VDD->VGH
+	dcs_write_seq(0x2A,0x41);	//STV2
+	dcs_write_seq(0x2B,0x43);	//STV4
+
+	//GIP_L_GS Pin mapping
+	dcs_write_seq(0x2C,0x1F);	//GCL
+	dcs_write_seq(0x2D,0x1E);	//VSS->VGH
+	dcs_write_seq(0x2E,0x0B);	//CLK1->CKV7
+	dcs_write_seq(0x2F,0x09);	//CKK3->CKV5
+	dcs_write_seq(0x30,0x07);	//CLK5->CKV3
+	dcs_write_seq(0x31,0x05);	//CLK7->CKV1
+	dcs_write_seq(0x32,0x1F);	//VGL
+	dcs_write_seq(0x33,0x1F);	//VGL
+	dcs_write_seq(0x34,0x1F);	//VGL
+	dcs_write_seq(0x35,0x1F);	//NC
+	dcs_write_seq(0x36,0x1F);	//NC
+	dcs_write_seq(0x37,0x1F);	//NC //
+	dcs_write_seq(0x38,0x1F);	//NC
+	dcs_write_seq(0x39,0x1F);	//NC
+	dcs_write_seq(0x3A,0x1F);	//NC //
+	dcs_write_seq(0x3B,0x1F);	//NC
+	dcs_write_seq(0x3C,0x1F);	//NC
+	dcs_write_seq(0x3D,0x1F);	//NC //
+	dcs_write_seq(0x3E,0x1E);	//GCH
+	dcs_write_seq(0x3F,0x1F);	//VDD->VGL
+	dcs_write_seq(0x40,0x03);	//STV1
+	dcs_write_seq(0x41,0x01);	//STV3
+
+	//GIP_R_GS Pin mapping
+	dcs_write_seq(0x42,0x1F);	//GCL
+	dcs_write_seq(0x43,0x1E);	//VSS->VGH
+	dcs_write_seq(0x44,0x0A);	//CLK2->CKV6
+	dcs_write_seq(0x45,0x08);	//CKK4->CKV4
+	dcs_write_seq(0x46,0x06);	//CLK6->CKV2
+	dcs_write_seq(0x47,0x04);	//CLK8->CKV0
+	dcs_write_seq(0x48,0x1F);	//VGL
+	dcs_write_seq(0x49,0x1F);	//VGL
+	dcs_write_seq(0x4A,0x1F);	//VGL
+	dcs_write_seq(0x4B,0x1F);	//NC
+	dcs_write_seq(0x4C,0x1F);	//NC
+	dcs_write_seq(0x4D,0x1F);	//NC //
+	dcs_write_seq(0x4E,0x1F);	//NC
+	dcs_write_seq(0x4F,0x1F);	//NC
+	dcs_write_seq(0x50,0x1F);	//NC //
+	dcs_write_seq(0x51,0x1F);	//NC
+	dcs_write_seq(0x52,0x1F);	//NC
+	dcs_write_seq(0x53,0x1F);	//NC //
+	dcs_write_seq(0x54,0x1E);	//GCH
+	dcs_write_seq(0x55,0x1F);	//VDD->VGL
+	dcs_write_seq(0x56,0x02);	//STV2
+	dcs_write_seq(0x57,0x00);	//STV4
+
+	//GIP Timing
+	dcs_write_seq(0x58,0x40);
+	dcs_write_seq(0x59,0x00);
+	dcs_write_seq(0x5A,0x00);
+	dcs_write_seq(0x5B,0x30);
+	dcs_write_seq(0x5C,0x0B); //STV_S0
+	dcs_write_seq(0x5D,0x30);
+	dcs_write_seq(0x5E,0x01);
+	dcs_write_seq(0x5F,0x02);
+	//dcs_write_seq(0x60,0x00);
+	//dcs_write_seq(0x61,0x01);
+	//dcs_write_seq(0x62,0x02);
+	dcs_write_seq(0x63,0x06);
+	dcs_write_seq(0x64,0x6A); //SETV_OFF
+	//dcs_write_seq(0x65,0x00);
+	//dcs_write_seq(0x66,0x00);
+	dcs_write_seq(0x67,0x73);
+	dcs_write_seq(0x68,0x0D); //CKV_S0
+	dcs_write_seq(0x69,0x06);
+	dcs_write_seq(0x6A,0x6A); //CKV_OFF,61(GOE=2.9)
+	dcs_write_seq(0x6B,0x10);
+	dcs_write_seq(0x6C,0x00);
+	dcs_write_seq(0x6D,0x04);
+	dcs_write_seq(0x6E,0x04);
+	dcs_write_seq(0x6F,0x88);
+	//dcs_write_seq(0x70,0x00);
+	//dcs_write_seq(0x71,0x00);
+	//dcs_write_seq(0x72,0x06);
+	//dcs_write_seq(0x73,0x7B);
+	//dcs_write_seq(0x74,0x00);
+	//dcs_write_seq(0x75,0x07);
+	//dcs_write_seq(0x76,0x00);
+	//dcs_write_seq(0x77,0x5D);
+	//dcs_write_seq(0x78,0x17);
+	//dcs_write_seq(0x79,0x1F);
+	//dcs_write_seq(0x7A,0x00);
+	//dcs_write_seq(0x7B,0x00);
+	//dcs_write_seq(0x7C,0x00);
+	//dcs_write_seq(0x7D,0x03);
+	//dcs_write_seq(0x7E,0x7B);
+
+	//Page4
+	dcs_write_seq(0xE0,0x04);
+	dcs_write_seq(0x00,0x0E);
+	dcs_write_seq(0x02,0xB3);
+	dcs_write_seq(0x09,0x60);
+	dcs_write_seq(0x0E,0x48);
+
+	//Page0
+	dcs_write_seq(0xE0,0x00);
+
+	dcs_write_seq(0x11);// SLPOUT
+	msleep (200);
+
+	dcs_write_seq(0x29);// DSiPON
+	msleep (100);
+
+
+	//--- TE----//
+	dcs_write_seq(0x35,0x00);
+
+	return 0;
+}
 
 static int cwu50_disable(struct drm_panel *panel)
 {
@@ -323,10 +590,10 @@ static int cwu50_prepare(struct drm_panel *panel)
 	if (ctx->prepared)
 		return 0;
 
-	gpiod_set_value_cansleep(ctx->reset_gpio, 0);
-	msleep(10);
-	gpiod_set_value_cansleep(ctx->reset_gpio, 1);
-	msleep(120);
+	//gpiod_set_value_cansleep(ctx->reset_gpio, 0);
+	//msleep(10);
+	//gpiod_set_value_cansleep(ctx->reset_gpio, 1);
+	//msleep(120);
 
 	/* Enabe tearing mode: send TE (tearing effect) at VBLANK */
 	ret = mipi_dsi_dcs_set_tear_on(dsi, MIPI_DSI_DCS_TEAR_MODE_VBLANK);
@@ -335,8 +602,11 @@ static int cwu50_prepare(struct drm_panel *panel)
 		return ret;
 	}
 	/* Exit sleep mode and power on */
-
-	cwu50_init_sequence(ctx);
+	ret = gpiod_get_value_cansleep(ctx->id_gpio);
+	if(ret)
+		cwu50_init_sequence2(ctx);
+	else
+		cwu50_init_sequence(ctx);
 
 	ret = mipi_dsi_dcs_exit_sleep_mode(dsi);
 	if (ret) {
@@ -422,9 +692,9 @@ static int cwu50_probe(struct mipi_dsi_device *dsi)
 	dsi->format = MIPI_DSI_FMT_RGB888;
 	dsi->mode_flags = MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST | MIPI_DSI_MODE_VIDEO_SYNC_PULSE;
 
-	ctx->reset_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_OUT_HIGH);
-	if (IS_ERR(ctx->reset_gpio)) {
-		ret = PTR_ERR(ctx->reset_gpio);
+	ctx->id_gpio = devm_gpiod_get_optional(dev, "reset", GPIOD_IN);
+	if (IS_ERR(ctx->id_gpio)) {
+		ret = PTR_ERR(ctx->id_gpio);
 		if (ret != -EPROBE_DEFER)
 			dev_err(dev, "failed to request GPIO (%d)\n", ret);
 		return ret;


### PR DESCRIPTION
Hi Rex

this is the patched drivers/gpu/drm/panel/panel-cwu50-cm4.c

for the future screen of uconsole, in future uconsole ,will use a different band screen instead.

Right now I only tested with CM4 version

old (current) screen and future screen both can work

In the Code use the id_gpio(original is reset_gpio) to determine if it is the future or old screen ,then use the corresponding init seqs

