### PR TITLE
arch: arm: dts: Add parameterized custom battery overlay for Clockwor…

### DIFF
--- a/arch/arm/boot/dts/overlays/Makefile
+++ b/arch/arm/boot/dts/overlays/Makefile
@@ -42,6 +42,7 @@ dtbo-$(CONFIG_ARCH_BCM2835) += \
 	chipcap2.dtbo \
 	chipdip-dac.dtbo \
 	cirrus-wm5102.dtbo \
+	clockworkpi-custom-battery.dtbo \
  	clockworkpi-devterm-cm3.dtbo \
 	clockworkpi-devterm-cm5.dtbo \
 	clockworkpi-devterm.dtbo \

--- a/arch/arm/boot/dts/overlays/clockworkpi-custom-battery-overlay.dts
+++ b/arch/arm/boot/dts/overlays/clockworkpi-custom-battery-overlay.dts
@@ -1,0 +1,19 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	compatible = "brcm,bcm2835";
+
+	fragment@0 {
+		target-path = "/battery@0";
+		frag0: __overlay__ {
+			energy-full-design-microwatt-hours = <24790000>;
+			charge-full-design-microamp-hours = <6700000>;
+		};
+	};
+
+	__overrides__ {
+		energy_full_design_uwh = <&frag0>, "energy-full-design-microwatt-hours:0";
+		charge_full_design_uah = <&frag0>, "charge-full-design-microamp-hours:0";
+	};
+};


### PR DESCRIPTION
…kPi devices

This adds a new device tree overlay, `clockworkpi-custom-battery`, that allows users to easily override the battery capacity set in the default device tree.

I'm not sure how many users have a battery mod, but I assume most people do have slightly different battery models, and having this set may allow axp228 to make better battery capacity estimations (with calibration).

To use this, add an extra

```
dtoverlay=clockworkpi-custom-battery,energy_full_design_uwh=...,charge_full_design_uah=...
```

in `config.txt` _after_ the respective board's dtoverlay defitions.

(replace `...` with their respective values)

For me, I have an extra 18500 2040mAh battery added, so I had to set

```
dtoverlay=clockworkpi-custom-battery,energy_full_design_uwh=32544000,charge_full_design_uah=9040000
```

This is a separate device tree overlay so that we don't need to add the parameter for every single ClockworkPi-related overlay.