### PR TITLE
power: supply: axp20x_battery: fix voltage_now cache assignment

### DIFF
--- a/drivers/power/supply/axp20x_battery.c
+++ b/drivers/power/supply/axp20x_battery.c
@@ -424,7 +424,7 @@ static int axp20x_battery_get_prop(struct power_supply *psy,
 
 		/* IIO framework gives mV but Power Supply framework gives uV */
 		val->intval *= 1000;
-		axp20x_batt->current_now = val->intval;
+		axp20x_batt->voltage_now = val->intval;
 
 		break;
 


### PR DESCRIPTION
## Bug

In `axp20x_battery_get_prop()`, the `POWER_SUPPLY_PROP_VOLTAGE_NOW` case incorrectly writes to `axp20x_batt->current_now` instead of `axp20x_batt->voltage_now`. This means `voltage_now` is never populated (stays 0), which causes `POWER_SUPPLY_PROP_POWER_NOW` to always return 0:

```c
case POWER_SUPPLY_PROP_POWER_NOW:
    val->intval = (axp20x_batt->voltage_now / 10000) *  // always 0
                  axp20x_batt->current_now;
```

## Effect

UPower classifies this battery as energy-reporting (because `energy_now` is present) and reads the discharge/charge rate directly from `power_now`. With `power_now` always 0, UPower reports `energy-rate: 0 W` and GNOME shows no time-to-empty or time-to-full estimate.

## Fix

One-character fix: change `current_now` to `voltage_now` in the `VOLTAGE_NOW` case so the cache is correctly populated.

## Tested on

uConsole CM5 (AXP221 PMIC), kernel 6.12.92-v8+. After fix:
- `power_now` reports ~8W when charging, ~5W when discharging
- UPower `energy-rate` is correct
- GNOME battery indicator shows time-to-full / time-to-empty